### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/java-library-tester/pom.xml
+++ b/java-library-tester/pom.xml
@@ -25,7 +25,7 @@
 		<lambdaj.version>2.4</lambdaj.version>
 		<guava.version>17.0</guava.version>
 		<cglib.version>2.2.2</cglib.version>
-		<commons-collections.version>3.2.1</commons-collections.version>
+		<commons-collections.version>3.2.2</commons-collections.version>
 
 		<!-- Json Util versions -->
 		<jackson.mapper.asl.version>1.8.5</jackson.mapper.asl.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
